### PR TITLE
OSOE-82: Updating SonarAnalyzer to latest to get rid of CS8032 errors with the .NET SDK v6.0.200

### DIFF
--- a/CommonPackages.props
+++ b/CommonPackages.props
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.0.43782">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Otherwise, we'll get tons of such errors (warnings):

```
Warning	CS8032	An instance of analyzer SonarAnalyzer.Rules.CSharp.DeliveringDebugFeaturesInProduction cannot be created from C:\Users\MyUser\.nuget\packages\sonaranalyzer.csharp\8.33.0.40503\analyzers\SonarAnalyzer.CSharp.dll: Method 'IsDevelopmentCheckInvoked' in type 'SonarAnalyzer.Rules.CSharp.DeliveringDebugFeaturesInProduction' from assembly 'SonarAnalyzer.CSharp, Version=8.33.0.0, Culture=neutral, PublicKeyToken=c5b62af9de6d7244' does not have an implementation..	CSM.Bynder		1	Active
```