### PR TITLE
HAST-187: S2228 is superseded by S106 so we shouldn't have the former enabled

### DIFF
--- a/General.ruleset
+++ b/General.ruleset
@@ -342,7 +342,6 @@
     <Rule Id="S1858" Action="Warning" />
     <Rule Id="S2148" Action="Warning" />
     <Rule Id="S2197" Action="Warning" />
-    <Rule Id="S2228" Action="Warning" />
     <Rule Id="S2278" Action="Warning" />
     <Rule Id="S2302" Action="Warning" />
     <Rule Id="S2330" Action="Warning" />


### PR DESCRIPTION
S2228 is superseded by S106 (https://github.com/SonarSource/sonar-dotnet/issues/1812) so we shouldn't have the former enabled.