### PR TITLE
OSOE-49: Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 * text=auto
 
-# Enforce Windows newlines for C# files to avoid false positives with IDE55 warning.
+# Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
 *.cs text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto
 
 # Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
-# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106
+# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106 for more information.
 *.cs text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 
 # Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
+# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106
 *.cs text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto
+
+# Enforce Windows newlines for C# files to avoid false positives with IDE55 warning.
+*.cs text eol=crlf

--- a/Build.props
+++ b/Build.props
@@ -29,7 +29,7 @@
   <ItemGroup>
     <!-- Note: This is fixed as of SDK version 6.0.202. If you need to build the solution on a system with an older SDK
          version, please uncomment the PackageReferences below. Leave this commented out unless you are certain you need
-         it, becuase it is a risky workaround as it makes us use the compiler from NuGet instead of the SDK, which is
+         it, because it is a risky workaround as it makes us use the compiler from NuGet instead of the SDK, which is
          unexpected and discouraged according to Microsoft.Net.Compilers.Toolset's Readme too.
          Fixing the <"error CS8032: An instance of analyzer Microsoft.CodeAnalysis.[...]Analyzer cannot be created from
          [...]\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll:

--- a/Build.props
+++ b/Build.props
@@ -27,7 +27,8 @@
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />
 
   <ItemGroup>
-    <!-- Fixing the <"error CS8032: An instance of analyzer Microsoft.CodeAnalysis.[...]Analyzer cannot be created from
+    <!-- Note: This is fixed as of SDK version 6.0.202, but it should not be removed until 6.0.200's lifecyle is over in May 22.
+         Fixing the <"error CS8032: An instance of analyzer Microsoft.CodeAnalysis.[...]Analyzer cannot be created from
          [...]\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll:
          Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.1.0.0, Culture=neutral,
          PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified.."> by

--- a/Build.props
+++ b/Build.props
@@ -27,13 +27,16 @@
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />
 
   <ItemGroup>
-    <!-- Note: This is fixed as of SDK version 6.0.202, but it should not be removed until 6.0.200's lifecyle is over in May 22.
+    <!-- Note: This is fixed as of SDK version 6.0.202. If you need to build the solution on a system with an older SDK
+         version, please uncomment the PackageReferences below. Leave this commented out unless you are certain you need
+         it, becuase it is a risky workaround as it makes us use the compiler from NuGet instead of the SDK, which is
+         unexpected and discouraged according to Microsoft.Net.Compilers.Toolset's Readme too.
          Fixing the <"error CS8032: An instance of analyzer Microsoft.CodeAnalysis.[...]Analyzer cannot be created from
          [...]\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll:
          Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.1.0.0, Culture=neutral,
          PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified.."> by
          adding "Microsoft.CodeAnalysis" AND "Microsoft.Net.Compilers" manually; see:
-         https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html -->
+         https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html
     <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
@@ -41,7 +44,7 @@
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
-    </PackageReference>
+    </PackageReference>  -->
   </ItemGroup>
 
   <!-- Packages only for .NET Core and later. -->


### PR DESCRIPTION
OSOE-49