### PR TITLE
OSOE-532: Update all NuGet dependencies

### DIFF
--- a/Lombiq.Analyzers/CommonPackages.props
+++ b/Lombiq.Analyzers/CommonPackages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
-    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.4"/>
+    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.5"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.4.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33"/>

--- a/Lombiq.Analyzers/CommonPackages.props
+++ b/Lombiq.Analyzers/CommonPackages.props
@@ -6,12 +6,12 @@
   <ItemGroup>
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
-    <AnalyzerPackage Include="Meziantou.Analyzer" Version="1.0.734"/>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.3.1"/>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0"/>
-    <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44"/>
+    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.4"/>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.4.0"/>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0"/>
+    <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.33"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
-    <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="8.47.0.55603"/>
+    <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="8.51.0.59060"/>
     <AnalyzerPackage Include="StyleCop.Analyzers" Version="1.2.0-beta.435"/>
   </ItemGroup>
 

--- a/Lombiq.Analyzers/Docs/UsingAnalyzersDuringDevelopment.md
+++ b/Lombiq.Analyzers/Docs/UsingAnalyzersDuringDevelopment.md
@@ -51,4 +51,6 @@ Example where the `#pragma` suppress is suitable (note how the suppression only 
     }
 ```
 
+Fence the smallest possible code block with such `#pragma`s, but do fence the whole code block where it applies (i.e. not necessarily just the line where you get an analyzer violation, since certain analyzer rules may work with multiple lines). This is also necessary because otherwise you may get a "IDE0079 Remove unnecessary suppression" violation.
+
 For further details see the [official docs](https://docs.microsoft.com/en-us/visualstudio/code-quality/in-source-suppression-overview).

--- a/Lombiq.Analyzers/general.ruleset
+++ b/Lombiq.Analyzers/general.ruleset
@@ -83,7 +83,6 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1002" Action="Hidden" />
-    <Rule Id="CA1014" Action="None" />
     <Rule Id="CA1051" Action="Hidden" />
     <Rule Id="CA2234" Action="Hidden" />
   </Rules>
@@ -108,6 +107,7 @@
     <Rule Id="CA1507" Action="Warning" />
     <Rule Id="CA1824" Action="Warning" />
     <Rule Id="CA1825" Action="Warning" />
+    <Rule Id="CA1851" Action="Warning" />
     <Rule Id="CA2016" Action="None" />
     <Rule Id="CA2234" Action="Hidden" />
     <Rule Id="CA3076" Action="Warning" />
@@ -119,7 +119,6 @@
     <Rule Id="CA1008" Action="Warning" />
     <Rule Id="CA1010" Action="Warning" />
     <Rule Id="CA1012" Action="Warning" />
-    <Rule Id="CA1014" Action="None" />
     <Rule Id="CA1016" Action="Warning" />
     <Rule Id="CA1018" Action="Warning" />
     <Rule Id="CA1024" Action="Warning" />
@@ -368,9 +367,9 @@
     <Rule Id="S3257" Action="Warning" />
     <Rule Id="S3353" Action="Warning" />
     <Rule Id="S3366" Action="Warning" />
-    <Rule Id="S3458" Action="None" />
     <Rule Id="S3376" Action="None" />
     <Rule Id="S3441" Action="Warning" />
+    <Rule Id="S3458" Action="None" />
     <Rule Id="S3532" Action="Warning" />
     <Rule Id="S3626" Action="None" />
     <Rule Id="S3693" Action="Warning" />

--- a/Lombiq.Analyzers/general.ruleset
+++ b/Lombiq.Analyzers/general.ruleset
@@ -80,6 +80,9 @@
     <Rule Id="MA0105" Action="Warning" />
     <Rule Id="MA0106" Action="None" />
     <Rule Id="MA0111" Action="None" />
+    <Rule Id="MA0120" Action="Warning" />
+    <Rule Id="MA0121" Action="Warning" />
+    <Rule Id="MA0122" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1002" Action="Hidden" />

--- a/TestSolutions/Lombiq.Analyzers.PackageReference/Lombiq.Analyzers.PackageReference.csproj
+++ b/TestSolutions/Lombiq.Analyzers.PackageReference/Lombiq.Analyzers.PackageReference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lombiq.Analyzers" Version="3.0.1">
+    <PackageReference Include="Lombiq.Analyzers" Version="3.0.2-alpha.1.osoe-532">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
[OSOE-532](https://lombiq.atlassian.net/browse/OSOE-532)
Notes:

- [NetAnalyzers 7.0.0](https://github.com/dotnet/roslyn-analyzers/releases/tag/7.0.0) has everything enabled by default apart from CA1851, which I also enabled.
- There are no release notes for `Meziantou.Analyzer` (see https://github.com/meziantou/Meziantou.Analyzer/issues/431). The original version was commit https://github.com/meziantou/Meziantou.Analyzer/commit/fc37e892ec38da12ec8e569fa5ac83d7aa980d34 and the new one is https://github.com/meziantou/Meziantou.Analyzer/commit/54879c0cddec74c1136798ef3b5cb3a3b2a7207d. The diff between the two: https://github.com/meziantou/Meziantou.Analyzer/compare/fc37e892ec38da12ec8e569fa5ac83d7aa980d34..54879c0cddec74c1136798ef3b5cb3a3b2a7207d There are a couple of new rules (see [the Readme diff](https://github.com/meziantou/Meziantou.Analyzer/compare/fc37e892ec38da12ec8e569fa5ac83d7aa980d34..54879c0cddec74c1136798ef3b5cb3a3b2a7207d#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), which are enabled by default or I've enabled them.

[OSOE-532]: https://lombiq.atlassian.net/browse/OSOE-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ