### PR TITLE
OSOE-636: Using _SkipUpgradeNetAnalyzersNuGetWarning in .NET Framework projects too

### DIFF
--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -29,11 +29,6 @@
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 
-  <!-- .NET-only packages. -->
-  <ItemGroup>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.7.0"/>
-  </ItemGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />
 
   <ItemGroup>

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -29,6 +29,11 @@
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 
+  <!-- .NET-only packages. -->
+  <ItemGroup>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.7.0"/>
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />
 
   <ItemGroup>

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -22,7 +22,8 @@
     .NET code style analysis is not working with .NET 5 though, see: https://github.com/dotnet/roslyn/issues/33558#issuecomment-867346974. -->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <!-- This prevents unnecessary warnings so the analyzer versions will depend on the repository and not what is
-    installed by the user. see: https://github.com/dotnet/docs/issues/23232. -->
+    installed by the user. See:
+    https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -18,12 +18,14 @@
     https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview#latest-updates -->
     <AnalysisLevel>7.0</AnalysisLevel>
     <!-- This is for Microsoft.CodeAnalysis.NetAnalyzers. This way, we have control over it unlike when getting it
-    via the .NET SDK. See: https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers
-    .NET code style analysis is not working with .NET 5 though, see: https://github.com/dotnet/roslyn/issues/33558#issuecomment-867346974. -->
+         via the .NET SDK. See:
+         https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers .NET
+         code style analysis is not working with .NET 5 though, see:
+         https://github.com/dotnet/roslyn/issues/33558#issuecomment-867346974. -->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <!-- This prevents unnecessary warnings so the analyzer versions will depend on the repository and not what is
-    installed by the user. See:
-    https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
+         installed by the user. See:
+         https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers/CommonPackages.props
+++ b/Lombiq.Analyzers/CommonPackages.props
@@ -7,7 +7,6 @@
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
     <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.85"/>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.7.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>

--- a/Lombiq.Analyzers/CommonPackages.props
+++ b/Lombiq.Analyzers/CommonPackages.props
@@ -8,7 +8,7 @@
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
     <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.85"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.7.0"/>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3"/>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
     <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="9.10.0.77988"/>

--- a/Lombiq.Analyzers/CommonPackages.props
+++ b/Lombiq.Analyzers/CommonPackages.props
@@ -7,6 +7,7 @@
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
     <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.85"/>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.7.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>

--- a/Lombiq.Analyzers/CommonPackages.props
+++ b/Lombiq.Analyzers/CommonPackages.props
@@ -8,7 +8,7 @@
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
     <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.85"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.7.0"/>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4"/>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
     <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="9.10.0.77988"/>

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -28,11 +28,6 @@
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 
-  <!-- .NET Framework-only packages. -->
-  <ItemGroup>
-    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.6.0"/>
-  </ItemGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />
 
   <ItemGroup>
@@ -47,7 +42,7 @@
          'C:\Users\runneradmin\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.7.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll' #spell-check-ignore-line
          references version '4.7.0.0' of the compiler, which is newer than the currently running version '4.6.0.0'."
          kind. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.6.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -28,6 +28,11 @@
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 
+  <!-- .NET Framework-only packages. -->
+  <ItemGroup>
+    <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.6.0"/>
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />
 
   <ItemGroup>
@@ -42,7 +47,7 @@
          'C:\Users\runneradmin\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.7.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll' #spell-check-ignore-line
          references version '4.7.0.0' of the compiler, which is newer than the currently running version '4.6.0.0'."
          kind. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -22,6 +22,10 @@
          https://github.com/dotnet/roslyn/blob/ff854c695779990b9b269029a8615782a59ec530/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets#L104.
          -->
     <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
+    <!-- This prevents unnecessary warnings so the analyzer versions will depend on the repository and not what is
+    installed by the user. See:
+    https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
+    <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)CommonPackages.props" />

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -25,7 +25,6 @@
     <!-- This prevents unnecessary warnings so the analyzer versions will depend on the repository and not what is
          installed by the user. See:
          https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
-    <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>etanalyzersnugetwarning. -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -38,7 +38,7 @@
          PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified.."> by
          adding "Microsoft.Net.Compilers.Toolset" manually; see:
          https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.6.0">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -23,8 +23,9 @@
          -->
     <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
     <!-- This prevents unnecessary warnings so the analyzer versions will depend on the repository and not what is
-    installed by the user. See:
-    https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
+         installed by the user. See:
+         https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#_skipupgradenetanalyzersnugetwarning. -->
+    <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>etanalyzersnugetwarning. -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -39,7 +39,7 @@
          https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html. Not updating this
          version in sync with the analyzer packages will result in errors of the "CSC : error CS9057: The analyzer
          assembly
-         'C:\Users\runneradmin\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.7.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll'
+         'C:\Users\runneradmin\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.7.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll' #spell-check-ignore-line
          references version '4.7.0.0' of the compiler, which is newer than the currently running version '4.6.0.0'."
          kind. -->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0">

--- a/Lombiq.Analyzers/NetFx.Build.props
+++ b/Lombiq.Analyzers/NetFx.Build.props
@@ -36,7 +36,12 @@
          Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.2.0.0, Culture=neutral,
          PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified.."> by
          adding "Microsoft.Net.Compilers.Toolset" manually; see:
-         https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html. -->
+         https://docs.microsoft.com/en-us/answers/questions/244179/microsoftcodeanalysis-problem.html. Not updating this
+         version in sync with the analyzer packages will result in errors of the "CSC : error CS9057: The analyzer
+         assembly
+         'C:\Users\runneradmin\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.7.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll'
+         references version '4.7.0.0' of the compiler, which is newer than the currently running version '4.6.0.0'."
+         kind. -->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>


### PR DESCRIPTION
[OSOE-636](https://lombiq.atlassian.net/browse/OSOE-636)

[OSOE-636]: https://lombiq.atlassian.net/browse/OSOE-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ