### PR TITLE
OSOE-760: Disable SA1518 since it's already covered by S113

### DIFF
--- a/Lombiq.Analyzers/Lombiq.Analyzers.globalconfig
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.globalconfig
@@ -649,6 +649,7 @@ dotnet_diagnostic.SA1503.severity = none
 dotnet_diagnostic.SA1512.severity = none
 dotnet_diagnostic.SA1515.severity = none
 dotnet_diagnostic.SA1516.severity = none
+dotnet_diagnostic.SA1518.severity = none
 dotnet_diagnostic.SA1519.severity = none
 dotnet_diagnostic.SA1601.severity = none
 dotnet_diagnostic.SA1602.severity = none


### PR DESCRIPTION
- warns on lacking newline at end of file