### PR TITLE
OSOE-852: Change NuGet metadata to use license expression

### DIFF
--- a/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.csproj
+++ b/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <!-- This project is built with an externally generated .nuspec file so NuGet-related properties are not needed here.

--- a/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.csproj
+++ b/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <!-- This is duplicated with Lombiq.Analyzers.NetFx.nuspec.template but is needed for the NuGet publishing workflow
-    not to throw a warning. See https://github.com/Lombiq/GitHub-Actions/issues/236. -->
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.nuspec.template
+++ b/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.nuspec.template
@@ -6,7 +6,6 @@
         <title>Lombiq .NET Analyzers for .NET Framework</title>
         <authors>Lombiq Technologies</authors>
         <license type="expression">BSD-3-Clause</license>
-        <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.NetFx</projectUrl>
         <description>Lombiq .NET Analyzers for .NET Framework: .NET code analyzers and code convention settings for .NET Framework projects. See the project website for detailed documentation.</description>

--- a/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.nuspec.template
+++ b/Lombiq.Analyzers.NetFx/Lombiq.Analyzers.NetFx.nuspec.template
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Lombiq .NET Analyzers for .NET Framework</title>
         <authors>Lombiq Technologies</authors>
-        <license type="file">License.md</license>
+        <license type="expression">BSD-3-Clause</license>
         <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.NetFx</projectUrl>

--- a/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.csproj
+++ b/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <!-- This is duplicated with Lombiq.Analyzers.Orchard1.nuspec.template but is needed for the NuGet publishing
-    workflow not to throw a warning. See https://github.com/Lombiq/GitHub-Actions/issues/236. -->
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.csproj
+++ b/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <!-- This project is built with an externally generated .nuspec file so NuGet-related properties are not needed here.

--- a/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.nuspec.template
+++ b/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.nuspec.template
@@ -6,7 +6,6 @@
         <title>Lombiq .NET Analyzers for Orchard 1</title>
         <authors>Lombiq Technologies</authors>
         <license type="expression">BSD-3-Clause</license>
-        <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.Orchard1</projectUrl>
         <description>Lombiq .NET Analyzers for Orchard 1: .NET code analyzers and code convention settings for Orchard 1 (https://orchardcore.net/orchardcms) apps. See the project website for detailed documentation.</description>

--- a/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.nuspec.template
+++ b/Lombiq.Analyzers.Orchard1/Lombiq.Analyzers.Orchard1.nuspec.template
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Lombiq .NET Analyzers for Orchard 1</title>
         <authors>Lombiq Technologies</authors>
-        <license type="file">License.md</license>
+        <license type="expression">BSD-3-Clause</license>
         <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.Orchard1</projectUrl>

--- a/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.csproj
+++ b/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <!-- This project is built with an externally generated .nuspec file so NuGet-related properties are not needed here.

--- a/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.csproj
+++ b/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <!-- This is duplicated with Lombiq.Analyzers.OrchardCore.nuspec.template but is needed for the NuGet publishing
-    workflow not to throw a warning. See https://github.com/Lombiq/GitHub-Actions/issues/236. -->
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.nuspec.template
+++ b/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.nuspec.template
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Lombiq .NET Analyzers for Orchard Core</title>
         <authors>Lombiq Technologies</authors>
-        <license type="file">License.md</license>
+        <license type="expression">BSD-3-Clause</license>
         <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.OrchardCore</projectUrl>

--- a/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.nuspec.template
+++ b/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.nuspec.template
@@ -6,7 +6,6 @@
         <title>Lombiq .NET Analyzers for Orchard Core</title>
         <authors>Lombiq Technologies</authors>
         <license type="expression">BSD-3-Clause</license>
-        <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.OrchardCore</projectUrl>
         <description>Lombiq .NET Analyzers for Orchard Core: .NET code analyzers and code convention settings for Orchard Core (https://orchardcore.net/) apps. See the project website for detailed documentation.</description>

--- a/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.csproj
+++ b/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <!-- This is duplicated with Lombiq.Analyzers.VisualStudioExtension.nuspec.template but is needed for the NuGet
-    publishing workflow not to throw a warning. See https://github.com/Lombiq/GitHub-Actions/issues/236. -->
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.csproj
+++ b/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <!-- This project is built with an externally generated .nuspec file so NuGet-related properties are not needed here.

--- a/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.nuspec.template
+++ b/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.nuspec.template
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Lombiq .NET Analyzers for Visual Studio Extensions</title>
         <authors>Lombiq Technologies</authors>
-        <license type="file">License.md</license>
+        <license type="expression">BSD-3-Clause</license>
         <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.VisualStudioExtension</projectUrl>

--- a/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.nuspec.template
+++ b/Lombiq.Analyzers.VisualStudioExtension/Lombiq.Analyzers.VisualStudioExtension.nuspec.template
@@ -6,7 +6,6 @@
         <title>Lombiq .NET Analyzers for Visual Studio Extensions</title>
         <authors>Lombiq Technologies</authors>
         <license type="expression">BSD-3-Clause</license>
-        <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers.VisualStudioExtension</projectUrl>
         <description>Lombiq .NET Analyzers for Visual Studio Extensions: .NET code analyzers and code convention settings for Visual Studio Extensions. See the project website for detailed documentation.</description>

--- a/Lombiq.Analyzers/Lombiq.Analyzers.csproj
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <!-- This project is built with an externally generated .nuspec file so NuGet-related properties are not needed here.

--- a/Lombiq.Analyzers/Lombiq.Analyzers.csproj
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);.git*;</DefaultItemExcludes>
-    <!-- This is duplicated with Lombiq.Analyzers.nuspec.template but is needed for the NuGet publishing workflow not to
-    throw a warning. See https://github.com/Lombiq/GitHub-Actions/issues/236. -->
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Lombiq.Analyzers/Lombiq.Analyzers.nuspec.template
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.nuspec.template
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Lombiq .NET Analyzers</title>
         <authors>Lombiq Technologies</authors>
-        <license type="file">License.md</license>
+        <license type="expression">BSD-3-Clause</license>
         <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers</projectUrl>

--- a/Lombiq.Analyzers/Lombiq.Analyzers.nuspec.template
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.nuspec.template
@@ -6,7 +6,6 @@
         <title>Lombiq .NET Analyzers</title>
         <authors>Lombiq Technologies</authors>
         <license type="expression">BSD-3-Clause</license>
-        <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
         <icon>NuGetIcon.png</icon>
         <projectUrl>https://github.com/Lombiq/.NET-Analyzers/blob/dev/Lombiq.Analyzers</projectUrl>
         <description>Lombiq .NET Analyzers: .NET code analyzers and code convention settings for general .NET projects. See the project website for detailed documentation.</description>


### PR DESCRIPTION
[OSOE-852](https://lombiq.atlassian.net/browse/OSOE-852)

Removed license url 
Because I was getting: The licenseUrl and license elements cannot be used together. 
See run: https://github.com/Lombiq/.NET-Analyzers/actions/runs/9469828261/job/26089385371#step:4:538 

[OSOE-852]: https://lombiq.atlassian.net/browse/OSOE-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ