### PR TITLE
LMBQ-360: Removing S6964 from warnings.

### DIFF
--- a/Lombiq.Analyzers/Lombiq.Analyzers.globalconfig
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.globalconfig
@@ -635,6 +635,8 @@ dotnet_diagnostic.S4432.severity = warning
 dotnet_diagnostic.S4487.severity = warning
 dotnet_diagnostic.S4564.severity = warning
 dotnet_diagnostic.S6934.severity = none
+# We don't utilize this rule. Warnings also don't show up in IDE.
+dotnet_diagnostic.S6964.severity = none
 dotnet_diagnostic.S881.severity = warning
 
 # StyleCop.Analyzers rules


### PR DESCRIPTION
[LMBQ-360](https://lombiq.atlassian.net/browse/LMBQ-360)

[LMBQ-360]: https://lombiq.atlassian.net/browse/LMBQ-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ