### PR TITLE
VSIX-67: Using Meziantou.Analyzer 2.0.110 for .NET Framework projects

### DIFF
--- a/Lombiq.Analyzers.NetFx/Build.props
+++ b/Lombiq.Analyzers.NetFx/Build.props
@@ -38,7 +38,8 @@
 
   <ItemGroup>
     <!-- This needs to be on 2.0.110 for .NET Framework projects, see
-    https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
+    https://github.com/meziantou/Meziantou.Analyzer/issues/791. If this can be updated, then move the package reference
+    to the common AnalyzerPackages.props file and remove the package rule in the root Renovate config file. -->
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.110" IncludeInPackage="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>

--- a/Lombiq.Analyzers.NetFx/Build.props
+++ b/Lombiq.Analyzers.NetFx/Build.props
@@ -9,6 +9,8 @@
     <DocumentationFile>$(DocumentationDir)/$(MSBuildProjectName).xml</DocumentationFile>
     <!-- Don't run analyzers during Visual Studio build to avoid local slowdown. They still run during dotnet build. -->
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+    <!-- <LangVersion> needn't be set since it's 7.3 for all .NET Framework projects:
+    https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning#defaults. -->
     <!-- Setting the analysis level explicitly lets us opt in to new analyzers with SDK upgrades. See:
          https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview#latest-updates. -->
     <AnalysisLevel>5.0</AnalysisLevel>

--- a/Lombiq.Analyzers.NetFx/Build.props
+++ b/Lombiq.Analyzers.NetFx/Build.props
@@ -37,6 +37,13 @@
   <Import Project="$(MSBuildThisFileDirectory)../Lombiq.Analyzers/AnalyzerPackages.props" />
 
   <ItemGroup>
+    <!-- This needs to be on 2.0.110 for .NET Framework projects, see
+    https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.110" IncludeInPackage="true">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
+    </PackageReference>
+    
     <!-- Fixing the <"error CS8032: An instance of analyzer Microsoft.CodeAnalysis.[...]Analyzer cannot be created from
          [...]\.nuget\packages\microsoft.codeanalysis.csharp.codestyle\4.2.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll:
          Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.2.0.0, Culture=neutral,

--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
-    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.189"/>
+    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.110"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61"/>

--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
-    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.110"/>
+    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.111"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61"/>

--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
-    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.111"/>
+    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.110"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61"/>

--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
-    <AnalyzerPackage Include="Meziantou.Analyzer" Version="2.0.110"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61"/>

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -35,6 +35,13 @@
   <Import Project="$(MSBuildThisFileDirectory)AnalyzerPackages.props" />
 
   <ItemGroup>
+    <!-- This needs to be on 2.0.110 for .NET Framework projects, see
+    https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.189" IncludeInPackage="true">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
+    </PackageReference>
+    
     <!-- Note: This is fixed as of SDK version 6.0.202. If you need to build the solution on a system with an older SDK
          version, please uncomment the PackageReferences below. Leave this commented out unless you are certain you need
          it, because it is a risky workaround as it makes us use the compiler from NuGet instead of the SDK, which is

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,5 +29,15 @@
             ],
             enabled: false,
         },
+        {
+            // Meziantou.Analyzer needs to be kept on the version in that file.
+            matchPackageNames: [
+                'Meziantou.Analyzer',
+            ],
+            matchFileNames: [
+                'Lombiq.Analyzers.NetFx/Build.props',
+            ],
+            enabled: false,
+        },
     ],
 }


### PR DESCRIPTION
[VSIX-67](https://lombiq.atlassian.net/browse/VSIX-67)
Because there are issues with more recent ones, see https://github.com/meziantou/Meziantou.Analyzer/issues/791.

[VSIX-67]: https://lombiq.atlassian.net/browse/VSIX-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ