### PR TITLE
OSOE-1229: Update dependency Meziantou.Analyzer to 2.0.278, AsyncFixer to v2, disabling AsyncFixer06

### DIFF
--- a/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.globalconfig
+++ b/Lombiq.Analyzers.OrchardCore/Lombiq.Analyzers.OrchardCore.globalconfig
@@ -7,6 +7,10 @@ global_level = 10
 # rename it to .editorconfig. This should eventually not be necessary, see https://github.com/dotnet/roslyn/issues/70326.
 
 
+# AsyncFixer rules
+# Flags too many instances of normal OC and ASP.NET Core API usage.
+dotnet_diagnostic.AsyncFixer06.severity = none
+
 # Microsoft.CodeAnalysis.CSharp rules
 dotnet_diagnostic.CS1591.severity = none
 

--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -4,7 +4,7 @@
   always test with both kind of projects.  -->
 
   <ItemGroup>
-    <AnalyzerPackage Include="AsyncFixer" Version="1.6.0"/>
+    <AnalyzerPackage Include="AsyncFixer" Version="2.1.0"/>
     <AnalyzerPackage Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0"/>
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -37,7 +37,7 @@
   <ItemGroup>
     <!-- This needs to be on 2.0.110 for .NET Framework projects, see
     https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.270" IncludeInPackage="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.278" IncludeInPackage="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
[OSOE-1229](https://lombiq.atlassian.net/browse/OSOE-1229)

[OSOE-1229]: https://lombiq.atlassian.net/browse/OSOE-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ