### PR TITLE
OSOE-1229: Updating Meziantou.Analyzer to 2.0.279 to fix false positives

### DIFF
--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -37,7 +37,7 @@
   <ItemGroup>
     <!-- This needs to be on 2.0.110 for .NET Framework projects, see
     https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.278" IncludeInPackage="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.279" IncludeInPackage="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
[OSOE-1229](https://lombiq.atlassian.net/browse/OSOE-1229)

[OSOE-1229]: https://lombiq.atlassian.net/browse/OSOE-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ