### PR TITLE
OSOE-1254: Update dependencies: SonarAnalyzer.CSharp 10.20.0 → 10.22.0, Meziantou.Analyzer 3.0.28 → 3.0.44

### DIFF
--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -10,7 +10,7 @@
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
-    <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="10.21.0.135717"/>
+    <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="10.22.0.136894"/>
     <AnalyzerPackage Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
   </ItemGroup>
 

--- a/Lombiq.Analyzers/AnalyzerPackages.props
+++ b/Lombiq.Analyzers/AnalyzerPackages.props
@@ -10,7 +10,7 @@
     <AnalyzerPackage Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0"/>
     <AnalyzerPackage Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15"/>
     <AnalyzerPackage Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
-    <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="10.20.0.135146"/>
+    <AnalyzerPackage Include="SonarAnalyzer.CSharp" Version="10.21.0.135717"/>
     <AnalyzerPackage Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
   </ItemGroup>
 

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -37,7 +37,7 @@
   <ItemGroup>
     <!-- This needs to be on 2.0.110 for .NET Framework projects, see
     https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.28" IncludeInPackage="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.34" IncludeInPackage="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>

--- a/Lombiq.Analyzers/Build.props
+++ b/Lombiq.Analyzers/Build.props
@@ -37,7 +37,7 @@
   <ItemGroup>
     <!-- This needs to be on 2.0.110 for .NET Framework projects, see
     https://github.com/meziantou/Meziantou.Analyzer/issues/791. -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.34" IncludeInPackage="true">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.44" IncludeInPackage="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
[OSOE-1254](https://lombiq.atlassian.net/browse/OSOE-1254): Update analyzer packages to latest versions.

- SonarAnalyzer.CSharp 10.20.0.135146 → 10.22.0.136894
- Meziantou.Analyzer 3.0.28 → 3.0.44

[OSOE-1254]: https://lombiq.atlassian.net/browse/OSOE-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ