### PR TITLE
OSOE-1311: Update Meziantou.Analyzer to 3.0.173

### DIFF
--- a/Lombiq.Analyzers/Meziantou.Analyzer.props
+++ b/Lombiq.Analyzers/Meziantou.Analyzer.props
@@ -6,14 +6,14 @@
        consuming project uses centralized package versions or not. -->
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
-    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" Version="3.0.159">
+    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" Version="3.0.173">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
-    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" VersionOverride="3.0.159">
+    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" VersionOverride="3.0.173">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>

--- a/Lombiq.Analyzers/Meziantou.Analyzer.props
+++ b/Lombiq.Analyzers/Meziantou.Analyzer.props
@@ -6,14 +6,14 @@
        consuming project uses centralized package versions or not. -->
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
-    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" Version="3.0.141">
+    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" Version="3.0.159">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
-    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" VersionOverride="3.0.141">
+    <PackageReference Include="Meziantou.Analyzer" IncludeInPackage="true" VersionOverride="3.0.159">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers;</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Renovate dependency integration for OSOE-1311.

- Merged `renovate/non-breaking-dependency-versions` (Meziantou.Analyzer 3.0.141 -> 3.0.159).
- Bumped further to 3.0.173 to pick up a fix for a known MA0075 false positive on conditional/compound expressions present in 3.0.159 (fixed upstream in 3.0.164, https://github.com/meziantou/Meziantou.Analyzer/releases/tag/3.0.164).
