### PR TITLE
OSOE-1312: Stop escalating MA0219 to warning/error

### DIFF
--- a/Lombiq.Analyzers/Lombiq.Analyzers.globalconfig
+++ b/Lombiq.Analyzers/Lombiq.Analyzers.globalconfig
@@ -79,6 +79,12 @@ dotnet_analyzer_diagnostic.category-CodeQuality.severity = warning
 # The "when-multiline:warning" config is not actually for cases when the if body is in another line so we have to turn
 # this off completely, see: https://github.com/dotnet/roslyn/issues/40912.
 dotnet_diagnostic.IDE0011.severity = none
+# MA0219: Set the language attribute in XML comment.
+# Its own docs say the default severity is hidden/IDE-only by design (it's just a convention, not part of the XML doc
+# spec, and tools may ignore it), see: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md.
+# Our blanket "Documentation" category escalation to warning (further escalated to error by warnaserror in CI) wasn't
+# meant to cover this one.
+dotnet_diagnostic.MA0219.severity = none
 # IDE0050: Convert to tuple
 # Quite dangerous as we most frequently use anonymous types to interface with other APIs (like generating routes) and
 # those can fail on this silently in runtime while building correctly.


### PR DESCRIPTION
Part of [OSOE-1312](https://lombiq.atlassian.net/browse/OSOE-1312) (follow-up fix).

Stops escalating `MA0219` (\"Set the language attribute in XML comment\") to warning (and, with CI's `-warnaserror`, to a build-breaking error). Its own docs say the default severity is hidden/IDE-only by design — it's only a convention, not part of the XML doc spec, and tools may ignore it: https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0219.md.

Our blanket `dotnet_analyzer_diagnostic.category-Documentation.severity = warning` escalation wasn't meant to cover this specific rule, and the Meziantou.Analyzer 3.0.173 → 3.0.200 bump (#203) fixed a previously-inverted condition that made this rule a no-op — so it started actually firing (and failing CI builds) across many existing files that were never meant to be flagged.


[OSOE-1312]: https://lombiq.atlassian.net/browse/OSOE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ